### PR TITLE
early return, avoid numbers, tag decide time

### DIFF
--- a/src/functions.coffee
+++ b/src/functions.coffee
@@ -157,7 +157,7 @@ learn = (msg, exp) ->
 			[w..., tag] = r.split(':')
 			word = w.join ':'
 
-			if word is ' '
+			if word.trim() is ''
 				continue
 
 			if tag is 'eng' or tag is 'x' or tag is 'm'

--- a/src/functions.coffee
+++ b/src/functions.coffee
@@ -157,13 +157,15 @@ learn = (msg, exp) ->
 			[w..., tag] = r.split(':')
 			word = w.join ':'
 
-			if word isnt ' '
-				tag = customTag word, tag
-				tags.push tag
-				words.push word
+			if word is ' '
+				continue
 
-				if tag is 'eng' or tag is 'x' or isCustomTag tag
-					unrecognized += 1
+			if tag is 'eng' or tag is 'x' or tag is 'm'
+				unrecognized += 1
+
+			tag = customTag word, tag
+			tags.push tag
+			words.push word
 
 		if unrecognized >= result.length * 0.6
 			console.log 'Not accepted because of too much unrecognized string.'


### PR DESCRIPTION
- Return early to avoid indenting. This is not lisp.
- Since all custom tags come from `x`, why don't we generate custom tags later?
- Kill the numbers.
